### PR TITLE
Use Easing.out on closeAnimation

### DIFF
--- a/package/src/utilities.ts
+++ b/package/src/utilities.ts
@@ -1,51 +1,59 @@
-import { TextInput } from "react-native"
-import Animated, { Easing } from "react-native-reanimated";
+import {TextInput} from 'react-native';
+import Animated, {Easing} from 'react-native-reanimated';
 
 export async function measureFocusedInputBottomYAsync() {
-    return new Promise<number>(resolve=>{
-        const input = TextInput.State.currentlyFocusedInput();
-        if(!input) return;
-        input.measure((x, y, width, height, pageX, pageY)=>{
-            resolve(pageY + height);
-        })
-    })
+  return new Promise<number>(resolve => {
+    const input = TextInput.State.currentlyFocusedInput();
+    if (!input) return;
+    input.measure((x, y, width, height, pageX, pageY) => {
+      resolve(pageY + height);
+    });
+  });
 }
 
-export function measureFocusedInputBottomY(callback: (bottomY: number)=>void) {
-    const input = TextInput.State.currentlyFocusedInput();
-    if(!input) return;
-    input.measure((x, y, width, height, pageX, pageY)=>{
-        callback(pageY + height);
-    })
+export function measureFocusedInputBottomY(
+  callback: (bottomY: number) => void,
+) {
+  const input = TextInput.State.currentlyFocusedInput();
+  if (!input) return;
+  input.measure((x, y, width, height, pageX, pageY) => {
+    callback(pageY + height);
+  });
 }
 
 export function measureInputBottomYAsync() {
-    return new Promise<number>(resolve=>{
-        measureFocusedInputBottomY(resolve)
-    })
+  return new Promise<number>(resolve => {
+    measureFocusedInputBottomY(resolve);
+  });
 }
 
 export function calcAndroidSystemPan({
-    keyboardEndY,
-    inputBottomY,
-} : {
-    keyboardEndY: number,
-    inputBottomY: number
+  keyboardEndY,
+  inputBottomY,
+}: {
+  keyboardEndY: number;
+  inputBottomY: number;
 }) {
-    const delta = inputBottomY - keyboardEndY;
-    return Math.max(0, delta);
+  const delta = inputBottomY - keyboardEndY;
+  return Math.max(0, delta);
 }
 
-export function closeAnimation(duration: number, easing: Animated.EasingFunction) {
-    return {
-        duration: duration + 50,
-        easing: Easing.in(easing)
-    }
+export function closeAnimation(
+  duration: number,
+  easing: Animated.EasingFunction,
+) {
+  return {
+    duration: duration + 50,
+    easing: Easing.out(easing),
+  };
 }
 
-export function openAnimation(duration: number, easing: Animated.EasingFunction) {
-    return {
-        duration,
-        easing: Easing.out(easing)
-    }
+export function openAnimation(
+  duration: number,
+  easing: Animated.EasingFunction,
+) {
+  return {
+    duration,
+    easing: Easing.out(easing),
+  };
 }


### PR DESCRIPTION
The `animationEasing` prop explanation says: "Open animation will use Easing.out(animationEasing), close animation will use Easing.in(animationEasing).". I tried it and it's indeed what happens.

But this is not how UI elements coming in and out of the screen is animated usually (keyboard for example). Google actually mentions it in their Material design guidelines. When things are coming into the screen, people usually expect them to start fast, then slowly snap into place. When things are going out of the screen, they either expect it to just go out fast, or start going out very fast and then slow down a bit towards the end. So for this use case, if both open and close uses Easing.out, I think it will be better.

If you set your `animationTime` to something unnecessarily big like `1000` and your `animationEasing` to something steep like `Easing.exp`, you can see the problem. When keyboard comes up, the animation will still feel consistent with the keyboard (even though unnecessarily long). When keyboard is going out of the screen, things won't feel consistent. Because keyboard will start going out fast, then slow a tiny bit towards the end while your component will ease at the start (as if there is a delay), then snap into place fast.